### PR TITLE
🚨 Fix critical CSS stylesheet typo causing complete styling failure

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>World Clock - GitHub MCP Demo</title>
-    <link rel="stylesheet" href="styls.css">
+    <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
## 🚨 Critical Fix: CSS Stylesheet Typo

**Fixes #4**

### Problem
The World Clock website was completely broken with no styling due to a typo in the CSS link reference.

### Root Cause
- **File**: `index.html` line 7
- **Issue**: `href="styls.css"` (missing 'e')
- **Impact**: Browser couldn't load stylesheet, causing complete visual breakdown

### Solution
✅ Changed `href="styls.css"` to `href="styles.css"`

### Verification
- [x] CSS file `styles.css` exists in repository
- [x] Typo corrected in HTML link reference
- [x] Website should now load with proper styling

### Testing
After merging, verify that:
1. Website loads with full styling applied
2. No 404 errors in browser console for CSS files
3. All visual elements display correctly

**This is a critical hotfix that restores the complete user experience.**