### PR TITLE
Critical Fix: Resolve CSS stylesheet link typo causing styling failure

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>World Clock - GitHub MCP Demo</title>
-    <link rel="stylesheet" href="styls.css">
+    <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
## 🐛 Critical Bug Fix: CSS Stylesheet Link Typo

### Problem
The World Clock website was completely unstyled due to a typo in the CSS link reference in `index.html`. Users were seeing only plain HTML without any visual styling, severely impacting the user experience.

### Root Cause
Line 7 in `index.html` contained a typo: `href="styls.css"` instead of `href="styles.css"` (missing 'e').

### Solution
✅ **Fixed the typo:** Changed `href="styls.css"` to `href="styles.css"`
✅ **Verified fix:** CSS file exists and loads properly
✅ **Tested:** Website now displays with full styling restored

### Changes Made
- **File:** `index.html`
- **Line:** 7
- **Change:** Fixed CSS link href attribute from `styls.css` → `styles.css`

### Impact
- ✅ CSS now loads correctly
- ✅ Full visual styling restored (colors, layout, fonts, animations)
- ✅ Professional appearance returned
- ✅ User experience significantly improved

### Testing
- Website now displays the beautiful World Clock interface
- All CSS styling, layout, and visual elements work as expected
- No broken styles or missing visual components

### Related Issue
Closes #11

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Critical priority (affects core user experience)

---
**Ready for Review:** This is a simple, critical fix that restores the website's visual appearance.