### PR TITLE
🐛 Fix CSS stylesheet typo causing styling failure

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>World Clock - GitHub MCP Demo</title>
-    <link rel="stylesheet" href="styls.css">
+    <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
## 🐛 Critical Bug Fix: CSS Stylesheet Not Loading

This PR fixes a critical styling issue where the World Clock website appeared completely unstyled due to a typo in the CSS link reference.

### 🔍 Problem
- **Issue**: CSS file not loading, website appears as plain HTML
- **Root Cause**: Typo in `index.html` line 7: `href="styls.css"` (missing 'e')
- **Impact**: Complete loss of styling across the entire website

### 🔧 Solution
- **Fix**: Changed `href="styls.css"` to `href="styles.css"`
- **Location**: `index.html` line 7
- **Type**: Single character addition (adding missing 'e')

### ✅ Testing
- [x] CSS file loads correctly in browser
- [x] Full styling restored (grid layout, colors, typography)
- [x] Responsive design working
- [x] Animations and hover effects functional
- [x] No console errors related to missing stylesheets

### 📁 Files Changed
- `index.html` - Fixed CSS link reference

### 🔗 Related
- Fixes #13 
- Branch: `hotfix/css-stylesheet-typo-#13`
- Target: `demo` branch

### 🚀 Impact
This critical fix restores the professional appearance of the World Clock website, ensuring users see the intended modern design instead of unstyled HTML.

**Before**: Plain HTML with default browser styling
**After**: Fully styled modern web application with custom design