### PR TITLE
🔥 Fix critical CSS stylesheet link typo - restores website styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>World Clock - GitHub MCP Demo</title>
-    <link rel="stylesheet" href="styls.css">
+    <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
## 🚨 Critical Hotfix: CSS Stylesheet Link Typo

### Problem
The World Clock website was completely broken with no styling applied due to a typo in the CSS link tag. The site appeared as plain, unstyled HTML, creating a critical user experience issue.

### Root Cause
**File:** `index.html` line 7  
**Issue:** CSS link had typo - `href="styls.css"` instead of `href="styles.css"`  
**Result:** Browser unable to load stylesheet (404 error)

### Solution
✅ **Fixed typo**: Changed `styls.css` → `styles.css`  
✅ **Minimal change**: Only added the missing 'e' character  
✅ **Verified**: CSS file exists and contains full styling  

### Impact After Fix
- ✨ Beautiful modern styling and layout restored
- 🎨 Custom color scheme (indigo/purple theme) working
- 📱 Responsive grid design functional
- 🎭 Smooth animations and hover effects enabled
- 📝 Professional Inter font typography loading

### Testing
- [x] CSS file loads successfully
- [x] No console errors in browser
- [x] Visual styling completely restored
- [x] Responsive design working across breakpoints

### Files Changed
- `index.html` - Fixed CSS link href attribute

**Closes #17**

---
**Type:** 🔥 Hotfix  
**Priority:** Critical  
**Branch:** `hotfix/css-stylesheet-typo-17` → `demo`